### PR TITLE
Add tag value checking feature to stop running ec2 instances

### DIFF
--- a/stop_running_ec2_instances/index.js
+++ b/stop_running_ec2_instances/index.js
@@ -39,7 +39,7 @@ function filterStoppableEc2InstanceIds(ec2Reservations) {
         return allInstances;
     }, []).filter((instance) => {
         return !instance.Tags || !instance.Tags.find((tag) => {
-            return tag.Key.toLowerCase() === 'donotstop'
+            return tag.Key.toLowerCase() === 'donotstop' && tag.Value.toLowerCase() === "false";
         });
     }).map((instance) => {
         return instance.InstanceId;


### PR DESCRIPTION
I added tag value check to stop running ec2 instances.